### PR TITLE
Adds delegation logic for mock connector.

### DIFF
--- a/CdpHelpers/InMemoryDelegationExecutor.cs
+++ b/CdpHelpers/InMemoryDelegationExecutor.cs
@@ -1,0 +1,276 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.PowerFx.Core.Entities;
+using Microsoft.PowerFx.Dataverse;
+using Microsoft.PowerFx.Dataverse.Eval.Delegation.QueryExpression;
+using Microsoft.PowerFx.Types;
+using Microsoft.Xrm.Sdk.Query;
+
+namespace CdpHelpers
+{
+    internal class InMemoryDelegationExecutor
+    {
+        public static IEnumerable<RecordValue> Execute(
+        TableValue sourceTable,
+        DataverseDelegationParameters parameters)
+        {
+            // 1) Pull out all the RecordValue rows
+            var rows = sourceTable
+                .Rows
+                .Where(dv => dv.IsValue)
+                .Select(dv => dv.Value)
+                .ToList();
+
+            // 2) Apply $filter
+            if (parameters.FxFilter != null)
+            {
+                rows = rows
+                    .Where(r => EvaluateFilter(parameters.FxFilter, r))
+                    .ToList();
+            }
+
+            // 3) Apply $orderby
+            if (parameters.OrderBy != null && parameters.OrderBy.Any())
+            {
+                rows = ApplyOrdering(rows, parameters.OrderBy).ToList();
+            }
+
+            // 4) Apply $top
+            if (parameters.Top.HasValue && parameters.Top.Value > 0)
+            {
+                rows = rows.Take(parameters.Top.Value).ToList();
+            }
+
+            // 5) Apply $select (projection)
+            if (parameters.ColumnMap != null)
+            {
+                rows = rows
+                    .Select(r => ProjectColumns(r, parameters.ColumnMap))
+                    .ToList();
+            }
+
+            if ((parameters.Joins != null && parameters.Joins.Any()) || (parameters.ColumnMap?.Any(c => c.IsDistinct || c.AggregateMethod != SummarizeMethod.None) == true))
+            {
+                throw new NotImplementedException("Join and aggregation not implemented in in‐memory mock.");
+            }
+
+            return rows;
+        }
+
+        private static bool EvaluateFilter(FxFilterExpression filter, RecordValue record)
+        {
+            // Combine sub‐filters:
+            if (filter.Filters?.Any() ?? false)
+            {
+                var op = filter.FilterOperator == FxFilterOperator.And
+                    ? new Func<bool, bool, bool>((a, b) => a && b)
+                    : new Func<bool, bool, bool>((a, b) => a || b);
+
+                return filter.Filters
+                    .Select(sub => EvaluateFilter(sub, record))
+                    .Aggregate(op);
+            }
+
+            // Combine conditions:
+            if (filter.Conditions?.Any() ?? false)
+            {
+                var op = filter.FilterOperator == FxFilterOperator.And
+                    ? new Func<bool, bool, bool>((a, b) => a && b)
+                    : new Func<bool, bool, bool>((a, b) => a || b);
+
+                return filter.Conditions
+                    .Select(cond => EvaluateCondition(cond, record))
+                    .Aggregate(op);
+            }
+
+            // no filter means include everything
+            return true;
+        }
+
+        private static bool EvaluateCondition(FxConditionExpression cond, RecordValue record)
+        {
+            // 1) Pull raw value from the record
+            var fv = record.GetField(cond.AttributeName);
+            object actualValue = fv switch
+            {
+                NumberValue nv => nv.Value,
+                DecimalValue dv => dv.Value,
+                StringValue sv => sv.Value,
+                GuidValue gv => gv.Value,
+                DateTimeValue dv => dv.Value,
+                DateValue dv => dv.Value,
+                TimeValue tv => tv.Value,
+                BooleanValue bv => bv.Value,
+                _ => throw new NotImplementedException($"Unhandled field type {fv.GetType().Name} for {cond.AttributeName}")
+            };
+
+            object compareTo = cond.Values.FirstOrDefault();
+
+            if (actualValue is decimal && compareTo is not decimal)
+            {
+                compareTo = Convert.ToDecimal(compareTo, CultureInfo.InvariantCulture);
+            }
+            else if (compareTo is decimal && actualValue is not decimal)
+            {
+                actualValue = Convert.ToDouble(actualValue, CultureInfo.InvariantCulture);
+            }
+
+            // Apply any FieldFunction
+            foreach (var ff in cond.FieldFunctions)
+            {
+                bool result = false;
+                switch (ff)
+                {
+                    case FieldFunction.StartsWith:
+                        result = ((string)actualValue)?.StartsWith((string)compareTo, StringComparison.InvariantCulture) ?? false;
+                        return result;
+                    case FieldFunction.EndsWith:
+                        result = ((string)actualValue)?.EndsWith((string)compareTo, StringComparison.InvariantCulture) ?? false;
+                        return result;
+                    case FieldFunction.Year:
+                        result = ((DateTime)actualValue).Year.Equals((int)compareTo);
+                        return result;
+                    case FieldFunction.Month:
+                        result = ((DateTime)actualValue).Month.Equals((int)compareTo);
+                        return result;
+                    case FieldFunction.Hour:
+                        result = ((DateTime)actualValue).Hour.Equals((int)compareTo);
+                        return result;
+                }
+            }
+
+            // Compare based on operator
+            switch (cond.Operator)
+            {
+                case FxConditionOperator.Equal:
+                    return Equals(actualValue, compareTo);
+
+                case FxConditionOperator.NotEqual:
+                    return !Equals(actualValue, compareTo);
+
+                case FxConditionOperator.GreaterThan:
+                    return ((IComparable)actualValue).CompareTo(compareTo) > 0;
+
+                case FxConditionOperator.GreaterEqual:
+                    return ((IComparable)actualValue).CompareTo(compareTo) >= 0;
+
+                case FxConditionOperator.LessThan:
+                    return ((IComparable)actualValue).CompareTo(compareTo) < 0;
+
+                case FxConditionOperator.LessEqual:
+                    return ((IComparable)actualValue).CompareTo(compareTo) <= 0;
+
+                case FxConditionOperator.Contains:
+                    return ((string)actualValue)?.Contains((string)compareTo, StringComparison.InvariantCulture) ?? false;
+
+                case FxConditionOperator.BeginsWith:
+                    return ((string)actualValue)?.StartsWith((string)cond.Values[0], StringComparison.InvariantCulture) ?? false;
+
+                case FxConditionOperator.EndsWith:
+                    return ((string)actualValue)?.EndsWith((string)cond.Values[0], StringComparison.InvariantCulture) ?? false;
+
+                case FxConditionOperator.Null:
+                    return actualValue == null;
+
+                case FxConditionOperator.NotNull:
+                    return actualValue != null;
+
+                case FxConditionOperator.ContainsValues:
+                    return cond.Values
+                        .Cast<object>()
+                        .Any(v => Equals(actualValue, v));
+
+                // … handle other operators as needed …
+
+                default:
+                    throw new NotSupportedException($"Operator {cond.Operator} not implemented in in‐memory mock.");
+            }
+        }
+
+        /// <summary>
+        /// Applies multi-column ordering to a sequence of RecordValue.
+        /// </summary>
+        private static IEnumerable<RecordValue> ApplyOrdering(
+            IEnumerable<RecordValue> rows,
+            IList<OrderExpression> orderBy)
+        {
+            // Nothing to do if no ordering specified
+            if (orderBy == null || !orderBy.Any())
+            {
+                return rows;
+            }
+
+            IOrderedEnumerable<RecordValue> orderedRows = null;
+
+            foreach (var orderExpr in orderBy)
+            {
+                // Build key selector for this column
+                Func<RecordValue, IComparable> keySelector =
+                    record => GetComparableField(record, orderExpr.AttributeName);
+
+                // First pass: OrderBy / OrderByDescending
+                if (orderedRows == null)
+                {
+                    orderedRows = orderExpr.OrderType == OrderType.Ascending
+                        ? rows.OrderBy(keySelector)
+                        : rows.OrderByDescending(keySelector);
+                }
+                else
+                {
+                    // Subsequent passes: ThenBy / ThenByDescending
+                    orderedRows = orderExpr.OrderType == OrderType.Ascending
+                        ? orderedRows.ThenBy(keySelector)
+                        : orderedRows.ThenByDescending(keySelector);
+                }
+            }
+
+            return orderedRows;
+        }
+
+        /// <summary>
+        /// Extracts a comparable CLR value from a RecordValue field.
+        /// </summary>
+        private static IComparable GetComparableField(RecordValue record, string fieldName)
+        {
+            var value = record.GetField(fieldName);
+
+            return value switch
+            {
+                NumberValue nv => nv.Value,
+                DecimalValue dv => dv.Value,
+                StringValue sv => sv.Value,
+                GuidValue gv => gv.Value,
+                DateTimeValue dv => dv.Value,
+                DateValue dv => dv.Value,
+                TimeValue tv => tv.Value,
+                BooleanValue bv => bv.Value,
+                _ => null
+            };
+        }
+
+        private static RecordValue ProjectColumns(
+            RecordValue row,
+            IEnumerable<FxColumnInfo> columnMap)
+        {
+            var resultRecordType = RecordType.Empty();
+            var columnValues = new List<NamedValue>();
+            foreach (var fxColumn in columnMap)
+            {
+                var colType = row.Type.GetFieldType(fxColumn.RealColumnName);
+                resultRecordType = resultRecordType.Add(fxColumn.RealColumnName, colType, fxColumn.AliasColumnName);
+                var colValue = row.GetField(fxColumn.RealColumnName);
+                columnValues.Add(new NamedValue(fxColumn.RealColumnName, colValue));
+            }
+
+            var resultRecordValue = FormulaValue.NewRecordFromFields(resultRecordType, columnValues);
+            return resultRecordValue;
+        }
+    }
+}

--- a/CdpHelpers/TableValueExtensions.cs
+++ b/CdpHelpers/TableValueExtensions.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using CdpHelpers;
+using Microsoft.PowerFx.Dataverse;
 using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
@@ -17,27 +19,25 @@ namespace Microsoft.PowerFx.Connectors
     {
         public static async Task<GetItemsResponse> ToGetItemsResponseAsync(this TableValue tableValue, IDictionary<string, string> odataParameters, CancellationToken cancellationToken)
         {
-            IEnumerable<DValue<RecordValue>> results;
+            IEnumerable<RecordValue> results;
 
             cancellationToken.ThrowIfCancellationRequested();
 
+            var record = tableValue.Type.ToRecord();
+            var parameters = record.Convert(odataParameters);
+
             if (tableValue is IDelegatableTableValue v2)
             {
-                // select, filter, top
-                var record = tableValue.Type.ToRecord();
-
-                var parameters = record.Convert(odataParameters);
-
 #pragma warning disable CS0618 // Type or member is obsolete
-
                 // $$$ Should use ExecuteQueryAsync instead which is returning a FormulaValue
-                results = await v2.GetRowsAsync(null, parameters, cancellationToken).ConfigureAwait(false);
+                var rows = await v2.GetRowsAsync(null, parameters, cancellationToken).ConfigureAwait(false);
+                results = rows.Select(r => r.Value).ToList();
 #pragma warning restore CS0618 // Type or member is obsolete
             }
             else
             {
                 // Trivial case for in-memory example when we don't support IDelegatableTableValue.
-                results = tableValue.Rows.ToArray();
+                results = InMemoryDelegationExecutor.Execute(tableValue, (DataverseDelegationParameters)parameters);
             }
 
             var resp = new GetItemsResponse();
@@ -45,11 +45,8 @@ namespace Microsoft.PowerFx.Connectors
 
             foreach (var result in results)
             {
-                if (result.IsValue)
-                {
-                    var dict = result.Value.GetODataValues();
-                    resp.value.Add(dict);
-                }
+                var dict = result.GetODataValues();
+                resp.value.Add(dict);
             }
 
             return resp;

--- a/CdpSampleWebApi/DataSource/TrivialTableProvider.cs
+++ b/CdpSampleWebApi/DataSource/TrivialTableProvider.cs
@@ -43,6 +43,42 @@ namespace CdpSampleWebApi
                     NumField = 30,
                     StrField = "Thirty"
                 },
+                new
+                {
+                    NumField = 40,
+                    StrField = "Forty"
+                },
+                new
+                {
+                    NumField = 50,
+                    StrField = "Fifty"
+                },
+                new
+                {
+                    NumField = 60,
+                    StrField = "Sixty"
+                },
+                new
+                {
+                    NumField = 70,
+                    StrField = "Seventy"
+                },
+                new
+                {
+                    NumField = 80,
+                    StrField = "Eighty"
+                },
+                new
+                {
+                    NumField = 90,
+                    StrField = "Ninety"
+                },
+                new
+                {
+                    NumField = 100,
+                    StrField = "Hundred"
+                }
+
             });
 
             _tables[_tableName] = (TableValue)result;


### PR DESCRIPTION
This pull request introduces a new in-memory delegation execution framework for handling OData-like operations on `TableValue` objects, improves the extensibility of `TableValueExtensions`, and updates sample data to support more comprehensive testing. Below are the most important changes grouped by theme:

### In-Memory Delegation Execution
* Added a new `InMemoryDelegationExecutor` class in `CdpHelpers/InMemoryDelegationExecutor.cs`. This class implements filtering, ordering, projection, and top operations (`$filter`, `$orderby`, `$top`, `$select`) on `TableValue` objects. It throws a `NotImplementedException` for unsupported operations like joins and aggregations.

### Enhancements to `TableValueExtensions`
* Updated the `ToGetItemsResponseAsync` method in `TableValueExtensions` to utilize the new `InMemoryDelegationExecutor` for non-delegatable tables. This ensures consistent handling of OData parameters such as `$filter` and `$top`.
* Changed the type of `results` from `IEnumerable<DValue<RecordValue>>` to `IEnumerable<RecordValue>` for better alignment with the new execution model.

### Dependency Updates
* Added a reference to the `CdpHelpers` namespace in `CdpHelpers/TableValueExtensions.cs` to integrate the new `InMemoryDelegationExecutor`.

### Expanded Sample Data
* Extended the sample data in `TrivialTableProvider` to include additional rows, ranging from `NumField = 40` to `NumField = 100`, to facilitate testing of filtering and ordering functionality.