### PR TITLE
Adds MIP Change to Sample

### DIFF
--- a/CdpHelpers/Protocol/CDPMetadataItem.cs
+++ b/CdpHelpers/Protocol/CDPMetadataItem.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace CdpHelpers.Protocol
+{
+    // This can be removed to use the original CDPSensitivityLabelInfo class from Fx Core once nugets are updated.
+    public class CDPSensitivityLabelInfoCopy
+    {
+        [JsonPropertyName("sensitivityLabelId")]
+        public string SensitivityLabelId { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("displayName")]
+        public string DisplayName { get; set; }
+
+        [JsonPropertyName("tooltip")]
+        public string Tooltip { get; set; }
+
+        [JsonPropertyName("priority")]
+        public int Priority { get; set; }
+
+        [JsonPropertyName("color")]
+        public string Color { get; set; }
+
+        // These are strings in your JSON; if you'd rather parse to bool, you can add a converter.
+        [JsonPropertyName("isEncrypted")]
+        public bool IsEncrypted { get; set; }
+
+        [JsonPropertyName("isEnabled")]
+        public bool IsEnabled { get; set; }
+
+        [JsonPropertyName("isParent")]
+        public bool IsParent { get; set; }
+
+        [JsonPropertyName("parentSensitivityLabelId")]
+        public string ParentSensitivityLabelId { get; set; }
+    }
+}

--- a/CdpHelpers/Protocol/TableMetadataSetting.cs
+++ b/CdpHelpers/Protocol/TableMetadataSetting.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CdpHelpers.Protocol
+{
+    /// <summary>
+    /// Settings for fetching table metadata.
+    /// </summary>
+    public class TableMetadataSetting
+    {
+        private readonly bool _extractSensitivityLabel;
+
+        public bool ExtractSensitivityLabel => _extractSensitivityLabel;
+
+        private readonly string _purviewAccountName;
+
+        public string PurviewAccountName => _purviewAccountName;
+
+        public TableMetadataSetting(bool extractSensitivityLabel = false, string purviewAccountName = null)
+        {
+            _extractSensitivityLabel = extractSensitivityLabel;
+            _purviewAccountName = purviewAccountName;
+        }
+    }
+}

--- a/CdpHelpers/Protocol/TableSchemaPoco.cs
+++ b/CdpHelpers/Protocol/TableSchemaPoco.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using CdpHelpers.Protocol;
 
 #pragma warning disable SA1300, IDE1006 // Elements should begin with an upper case
 #pragma warning disable CA1708 // Identifiers should differ by more than case
@@ -42,6 +43,9 @@ namespace Microsoft.PowerFx.Connectors
             // What filter capabilities?
             [JsonPropertyName("x-ms-capabilities")]
             public ColumnCapabilitiesPoco capabilities { get; set; }
+
+            [JsonPropertyName("x-ms-content-sensitivityLabelInfo")]
+            public IEnumerable<CDPSensitivityLabelInfoCopy> sensitivityLabels { get; set; }
         }
     }
 }

--- a/CdpHelpers/UtilityExtensions.cs
+++ b/CdpHelpers/UtilityExtensions.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CdpHelpers.Protocol;
 using Microsoft.PowerFx.Core.Functions.Delegation;
+using Microsoft.PowerFx.Types;
 
 namespace Microsoft.PowerFx.Connectors
 {
@@ -66,6 +68,25 @@ namespace Microsoft.PowerFx.Connectors
             }
 
             return options;
+        }
+
+        internal static CDPSensitivityLabelInfoCopy GetMockSensitivityLabelInfo()
+        {
+            var result = new CDPSensitivityLabelInfoCopy
+            {
+                SensitivityLabelId = Guid.NewGuid().ToString(),
+                Name = "Microsoft All Employees",
+                DisplayName = "Confidential \\ Microsoft Extended",
+                Tooltip = null,
+                Priority = 5,
+                Color = "#FF8C00",
+                IsEncrypted = false,
+                IsEnabled = false,
+                IsParent = false,
+                ParentSensitivityLabelId = Guid.NewGuid().ToString(),
+            };
+
+            return result;
         }
     }
 }

--- a/CdpSampleWebApi/Controllers/CdpController.cs
+++ b/CdpSampleWebApi/Controllers/CdpController.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System.Text.Json;
+using CdpHelpers.Protocol;
 using CdpSampleWebApi.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.PowerFx.Connectors;
@@ -72,12 +73,15 @@ namespace CdpSampleWebApi.Controllers
         public async Task<GetTableResponse> GetTableInfo(
             string dataset,
             string tableName,
-            [FromQuery(Name = "api-version")] string apiVersion)
+            [FromQuery(Name = "api-version")] string apiVersion,
+            [FromQuery(Name = "extractSensitivityLabel")] bool extractSensitivityLabel = false,
+            [FromQuery(Name = "purviewAccountName")] string purviewAccountName = null)
         {
             var provider = GetProvider();
+            var metadataSetting = new TableMetadataSetting(extractSensitivityLabel, purviewAccountName);
             RecordType record = await provider.GetTableAsync(dataset, tableName, CancellationToken.None).ConfigureAwait(true);
 
-            GetTableResponse resp = record.ToTableResponse(tableName);
+            GetTableResponse resp = record.ToTableResponse(tableName, metadataSetting);
 
             return resp;
         }

--- a/PowerPlatformArtifacts/apiDefinition.swagger.json
+++ b/PowerPlatformArtifacts/apiDefinition.swagger.json
@@ -11,7 +11,7 @@
       "CdpSample"
     ]
   },
-  "host": "testcdpconnector-sample5adar.eastus-01.azurewebsites.net",
+  "host": "testcdpconnector-cxg7debrffd5adar.eastus-01.azurewebsites.net",
   "basePath": "/",
   "schemes": [
     "https"
@@ -122,7 +122,7 @@
         "deprecated": false,
         "x-ms-visibility": "internal"
       }
-    }, 
+    },
     "/datasets/{datasets}/tables/{tableName}/items": {
       "get": {
         "tags": [
@@ -226,7 +226,7 @@
         "deprecated": false,
         "x-ms-visibility": "internal"
       }
-    },    
+    },
     "/datasets/{dataset}/tables": {
       "get": {
         "tags": [
@@ -270,7 +270,7 @@
           "nextLinkName": "@odata.nextLink"
         }
       }
-    }    
+    }
   },
   "definitions": {
     "BlobDataSetsMetadata": {


### PR DESCRIPTION
This pull request introduces support for handling sensitivity label information in table metadata and updates the API to allow for additional metadata settings. Key changes include the addition of new classes for handling sensitivity labels, modifications to existing methods to incorporate these labels, and updates to the API definition to support new query parameters.

### New functionality for sensitivity label handling:
* [`CdpHelpers/Protocol/CDPMetadataItem.cs`](diffhunk://#diff-ed186bd8e85dfa12e82ffc6bb9f94d3e57efdfe19b670b73dc9e89e8dec620ffR1-R47): Introduced the `CDPSensitivityLabelInfoCopy` class to represent sensitivity label information. This class includes properties such as `SensitivityLabelId`, `Name`, `DisplayName`, and others.
* [`CdpHelpers/UtilityExtensions.cs`](diffhunk://#diff-0bb443e8011251f129f2140cabc39459a360a6c699d237755555caa62c7380a6R72-R90): Added the `GetMockSensitivityLabelInfo` method to generate mock sensitivity label data.

### Updates to table metadata processing:
* [`CdpHelpers/Protocol/TableMetadataSetting.cs`](diffhunk://#diff-3f99b4df88c25cf8f5675c82a071c074fd2a23777e695fa48ba8799021cc19eeR1-R31): Added the `TableMetadataSetting` class to encapsulate settings for fetching table metadata, including whether to extract sensitivity labels and the Purview account name.
* [`CdpHelpers/RecordTypeExtensions.cs`](diffhunk://#diff-2dec7c9d0748eddff05eaffeaf9acd787c2dca26c9f2d874a1b019c769203dc0L68-R69): Modified the `ToTableSchemaPoco` and `ToTableResponse` methods to accept a `TableMetadataSetting` parameter and include sensitivity labels in the schema if enabled. [[1]](diffhunk://#diff-2dec7c9d0748eddff05eaffeaf9acd787c2dca26c9f2d874a1b019c769203dc0L68-R69) [[2]](diffhunk://#diff-2dec7c9d0748eddff05eaffeaf9acd787c2dca26c9f2d874a1b019c769203dc0R118-R132) [[3]](diffhunk://#diff-2dec7c9d0748eddff05eaffeaf9acd787c2dca26c9f2d874a1b019c769203dc0L135-R145) [[4]](diffhunk://#diff-2dec7c9d0748eddff05eaffeaf9acd787c2dca26c9f2d874a1b019c769203dc0L145-R155)

### API enhancements:
* [`CdpSampleWebApi/Controllers/CdpController.cs`](diffhunk://#diff-6501533621ed051459c6966d1b404427730d53d4265c5a92214ee23af81a1ebeL75-R84): Updated the `GetTableInfo` method to accept new query parameters (`extractSensitivityLabel` and `purviewAccountName`) and pass them to the `TableMetadataSetting` class.

### Miscellaneous updates:
* [`PowerPlatformArtifacts/apiDefinition.swagger.json`](diffhunk://#diff-2955cd67e7108226258033f4d5a69d83a94ca377d20795e8357d2a92e0167cedL14-R14): Updated the `host` field in the API definition to reflect a new endpoint.