### PR TITLE
add repl test

### DIFF
--- a/CdpSampleWebApi.sln
+++ b/CdpSampleWebApi.sln
@@ -31,6 +31,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PowerPlatformArtifacts", "P
 		PowerPlatformArtifacts\settings.json = PowerPlatformArtifacts\settings.json
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReplTest", "ReplTest\ReplTest.csproj", "{3E259BA4-7C3C-44C5-AD7F-565E9AE599A8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +55,10 @@ Global
 		{BCA7D531-F746-4566-B573-BF2AC36978C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BCA7D531-F746-4566-B573-BF2AC36978C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BCA7D531-F746-4566-B573-BF2AC36978C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3E259BA4-7C3C-44C5-AD7F-565E9AE599A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3E259BA4-7C3C-44C5-AD7F-565E9AE599A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3E259BA4-7C3C-44C5-AD7F-565E9AE599A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3E259BA4-7C3C-44C5-AD7F-565E9AE599A8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ReplTest/Program.cs
+++ b/ReplTest/Program.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.PowerFx;
+using Microsoft.PowerFx.Connectors;
+using Microsoft.PowerFx.Types;
+
+namespace ReplTest
+{
+    internal class Program
+    {
+        public static void Main(string[] args)
+        {
+            Console.WriteLine("Power Fx Repl for Tabular Connectors!");
+
+            WorkAsync().Wait();
+        }
+
+        public static async Task WorkAsync()
+        {
+            // Add tabular connector to the repl
+            string uri = "https://localhost:7157";
+            string dataset = "default";
+
+            HttpClient client = new HttpClient
+            {
+                BaseAddress = new Uri(uri)
+            };
+            
+            // Get tables. 
+            CdpDataSource cds = new CdpDataSource(dataset);
+            string prefix = string.Empty;
+            var tables = await cds.GetTablesAsync(client, prefix, default);
+
+            var symbolValues = new SymbolValues("Connectors");
+
+            Console.WriteLine($"Adding tables from '{dataset}' at {uri}:");
+            foreach (var connectorTable in tables)
+            {
+                string name = connectorTable.TableName;
+                Console.WriteLine($"  {name}");
+
+                await connectorTable.InitAsync(client, prefix, default);
+
+                TableValue tableValue = connectorTable.GetTableValue();
+
+                symbolValues.Add(name, tableValue);
+            }
+
+            MyContext ctx = new MyContext
+            {
+                _client = client
+            };
+
+            var runtimeServices = new BasicServiceProvider();
+
+            var engine = new RecalcEngine();
+
+            runtimeServices.AddRuntimeContext(ctx);
+
+            var repl = new PowerFxREPL();
+            repl.Engine = engine;
+            repl.ExtraSymbolValues = symbolValues;
+            repl.InnerServices = runtimeServices;
+
+            // Run the repl. 
+            while (true)
+            {
+                await repl.WritePromptAsync();
+
+                var line = Console.ReadLine();
+
+                await repl.HandleLineAsync(line);
+            }
+        }
+
+        private class MyContext : BaseRuntimeConnectorContext
+        {
+            public override TimeZoneInfo TimeZoneInfo => TimeZoneInfo.Local;
+
+            public HttpClient _client;
+
+            public override HttpMessageInvoker GetInvoker(string @namespace)
+            {
+                return _client;
+            }
+        }
+    }
+}

--- a/ReplTest/ReplTest.csproj
+++ b/ReplTest/ReplTest.csproj
@@ -1,0 +1,31 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <IsPackable>false</IsPackable>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+
+    <Import Project="..\PowerFxBuild.props" />
+
+
+    <PropertyGroup>
+        <NoWarn>1701;1702;1998;NU1605;CA1303;CA2007</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="YamlDotNet" Version="13.4.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.PowerFx.Connectors" Version="$(PowerFxVersion)" />
+        <PackageReference Include="Microsoft.PowerFx.Repl" Version="$(PowerFxVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
+    </ItemGroup>
+
+</Project>

--- a/ReplTest/readme.md
+++ b/ReplTest/readme.md
@@ -1,0 +1,14 @@
+# Power Fx Repl with Tabular Connectors
+
+This launches a Power Fx REPL and uses the connector SDK  to connect to a Tabular Connector instance. 
+
+By default, it will connect to the localhost instance. 
+
+## To run
+
+1. First launch the CdpSampleWebApi tabular connector. This should spin up on localhost at https://localhost:7157
+1. Then launch the ReplTest console app. This will initialize a Power Fx engine and include the connector at https://localhost:7157.
+1. You can then enter Power Fx repl commands against the connector, like `First(table)`, Filter, CountRows, etc. 
+
+
+


### PR DESCRIPTION
@gregli-msft asked for a Repl example that calls tabular connectors. 

This also provides an easy way to do adhoc local testing against the connector. 

<img width="484" alt="image" src="https://github.com/user-attachments/assets/640ab503-f7cc-4037-a8dd-387a07e89a2c" />

